### PR TITLE
CVE-2021-36942 patch bypass + alternative pipes support

### DIFF
--- a/EfsPotato.cs
+++ b/EfsPotato.cs
@@ -22,7 +22,7 @@ namespace Zcg.Exploits.Local
         }
         static void Main(string[] args)
         {
-            Console.WriteLine("Exploit for EfsPotato(MS-EFSR EfsRpcOpenFileRaw with SeImpersonatePrivilege local privalege escalation vulnerability).");
+            Console.WriteLine("Exploit for EfsPotato(MS-EFSR EfsRpcEncryptFileSrv with SeImpersonatePrivilege local privalege escalation vulnerability).");
             Console.WriteLine("Part of GMH's fuck Tools, Code By zcgonvh.");
             Console.WriteLine("CVE-2021-36942 patch bypass (EfsRpcEncryptFileSrv method) + alternative pipes support by Pablo Martinez (@xassiz) [www.blackarrow.net]\r\n");
             if (args.Length < 1)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-## Exploit for EfsPotato(MS-EFSR EfsRpcOpenFileRaw with SeImpersonatePrivilege local privalege escalation vulnerability).
+## Exploit for EfsPotato(MS-EFSR EfsRpcEncryptFileSrv with SeImpersonatePrivilege local privalege escalation vulnerability).
 
 ### build
 
@@ -12,7 +12,8 @@
 
 ### usage
 
-	EfsPotato <command>
+	usage: EfsPotato <cmd> [pipe]
+  	  pipe -> lsarpc|efsrpc|samr|lsass|netlogon (default=lsarpc)
 
 ![](https://raw.githubusercontent.com/zcgonvh/EfsPotato/master/test.png)
  


### PR DESCRIPTION
CVE-2021-36942 **patch bypass** (`EfsRpcEncryptFileSrv` method instead of `EfsRpcOpenFileRaw`) + **alternative pipes** support (defaults to `lsarpc`)